### PR TITLE
Use custom app icon across windows and build

### DIFF
--- a/AppConfig.py
+++ b/AppConfig.py
@@ -10,6 +10,7 @@ import tempfile
 import shutil
 import time
 from typing import Dict, Any, Tuple
+from icon_helper import set_app_icon
 
 try:
     # Import lazily-safe: these may be unavailable in headless contexts
@@ -308,6 +309,10 @@ def ensure_pdf_dir_selected(root=None) -> str:
             try:
                 if root is None and Tk is not None:
                     temp_root = Tk()
+                    try:
+                        set_app_icon(temp_root)
+                    except Exception:
+                        pass
                     temp_root.withdraw()
                 messagebox.showinfo(
                     "Dossier d’exportation PDF requis",

--- a/MainApp.py
+++ b/MainApp.py
@@ -1,4 +1,4 @@
-import os, sys, platform
+import os, sys
 import tkinter as tk
 from PIL import Image, ImageTk  # pillow is in requirements
 import ttkbootstrap as ttk
@@ -13,6 +13,7 @@ from Pay import PayTab
 from AppConfig import ensure_pdf_dir_selected, ensure_default_employee_files
 from updater import maybe_auto_check
 from version import APP_NAME, APP_VERSION
+from icon_helper import set_app_icon
 
 
 # ---------- Resource & Icon helpers (dev + PyInstaller) ----------
@@ -23,37 +24,6 @@ def _resource_path(relative_path: str) -> str:
     """
     base_path = getattr(sys, "_MEIPASS", os.path.abspath("."))
     return os.path.join(base_path, relative_path)
-
-def set_app_icon(root, keep_ref_container: dict | None = None):
-    """
-    Try platform-preferred icon first (.ico on Windows via iconbitmap),
-    then fall back to a PNG via wm_iconphoto (cross‑platform).
-    keep_ref_container keeps a reference to PhotoImage to avoid GC.
-    """
-    system = platform.system().lower()
-    ico_path = _resource_path("assets/icons/app_icon.ico")
-    png_path = _resource_path("assets/icons/app_icon.png")
-
-    if system == "windows" and os.path.exists(ico_path):
-        try:
-            root.iconbitmap(ico_path)
-            return
-        except Exception:
-            pass  # fall back to PNG
-
-    if os.path.exists(png_path):
-        try:
-            photo = ImageTk.PhotoImage(Image.open(png_path))
-            root.wm_iconphoto(True, photo)
-            # prevent image from being garbage‑collected
-            if keep_ref_container is not None:
-                keep_ref_container["_app_icon_photo"] = photo
-            else:
-                root._app_icon_photo = photo
-            return
-        except Exception:
-            pass
-    # If neither worked, silently continue (no icon set).
 
 
 # ---------- Splash / Loading screen ----------

--- a/MainApp.spec
+++ b/MainApp.spec
@@ -43,4 +43,5 @@ exe = EXE(
     target_arch=None,
     codesign_identity=None,
     entitlements_file=None,
+    icon='assets/icons/app_icon.ico',
 )

--- a/PunchClock.py
+++ b/PunchClock.py
@@ -2,6 +2,7 @@ import ttkbootstrap as ttk
 from ttkbootstrap.constants import *
 from tkinter import Toplevel
 from datetime import datetime, timedelta
+from icon_helper import set_app_icon
 
 
 class PunchClockPopup:
@@ -20,6 +21,8 @@ class PunchClockPopup:
         self.selected_minute_btn = None
 
         self.window = Toplevel(master)
+        self._icon_refs = {}
+        set_app_icon(self.window, self._icon_refs)
         employee_selected = master.item(row_id, "values")[1]  # column 1 is the name
         self.window.title(f"Sélectionner les heures pour     {employee_selected}")
         self.window.grab_set()

--- a/icon_helper.py
+++ b/icon_helper.py
@@ -1,0 +1,40 @@
+import os, sys, platform
+from PIL import Image, ImageTk
+
+
+def _resource_path(relative_path: str) -> str:
+    """Return absolute path to resource for dev and PyInstaller."""
+    base_path = getattr(sys, "_MEIPASS", os.path.abspath("."))
+    return os.path.join(base_path, relative_path)
+
+
+def set_app_icon(root, keep_ref_container: dict | None = None):
+    """Set the application icon on a Tk window.
+
+    Tries platform-preferred icon first (.ico on Windows via iconbitmap),
+    then falls back to a PNG via wm_iconphoto (cross‑platform). Optional
+    keep_ref_container keeps a reference to PhotoImage to avoid GC.
+    """
+    system = platform.system().lower()
+    ico_path = _resource_path("assets/icons/app_icon.ico")
+    png_path = _resource_path("assets/icons/app_icon.png")
+
+    if system == "windows" and os.path.exists(ico_path):
+        try:
+            root.iconbitmap(ico_path)
+            return
+        except Exception:
+            pass  # fall back to PNG
+
+    if os.path.exists(png_path):
+        try:
+            photo = ImageTk.PhotoImage(Image.open(png_path))
+            root.wm_iconphoto(True, photo)
+            if keep_ref_container is not None:
+                keep_ref_container["_app_icon_photo"] = photo
+            else:
+                root._app_icon_photo = photo
+            return
+        except Exception:
+            pass
+    # If neither worked, silently continue (no icon set).


### PR DESCRIPTION
## Summary
- Centralize Tk icon logic in new helper
- Apply app icon to all Tk windows and dialogs
- Embed icon in PyInstaller spec for branded executable

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b50c7c992883269c41894435463911