### PR TITLE
Add debug logging for timesheet confirmation

### DIFF
--- a/debug_log.py
+++ b/debug_log.py
@@ -1,0 +1,17 @@
+import os
+from datetime import datetime
+
+# Determine log file location in the user's home directory
+LOG_FILE = os.path.join(os.path.expanduser("~"), "TipSplit_debug.log")
+
+def log_debug(message):
+    """Append a timestamped debug message to the log file and print it."""
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    line = f"[{timestamp}] {message}"
+    try:
+        with open(LOG_FILE, "a", encoding="utf-8") as f:
+            f.write(line + "\n")
+    except Exception:
+        # Ensure logging never raises an exception
+        pass
+    print(line)


### PR DESCRIPTION
## Summary
- Add `debug_log` module to write timestamped messages to `TipSplit_debug.log`
- Replace `print` statements in time sheet export with robust file-backed logging and exception handling

## Testing
- `python -m py_compile TimeSheet.py debug_log.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5166247f48326858606542009b000