### PR TITLE
Enable DPI-aware scaling for consistent UI

### DIFF
--- a/Distribution.py
+++ b/Distribution.py
@@ -3,6 +3,7 @@ from ttkbootstrap.constants import *
 from PayPeriods import get_selected_period
 from Export import export_distribution_from_tab
 from datetime import datetime
+from ui_scale import scale
 
 class DistributionTab:
     def __init__(self, root, shared_data):
@@ -172,7 +173,7 @@ class DistributionTab:
             self.distribution_tree.heading(col, text=headers[col])
             width = 180 if col == "name" else 90
             anchor = W if col == "name" else CENTER
-            self.distribution_tree.column(col, width=width, anchor=anchor)
+            self.distribution_tree.column(col, width=scale(width), anchor=anchor)
 
         self.distribution_tree.pack(fill=BOTH, expand=True)
         self.distribution_tree.tag_configure("section", font=("Helvetica", 14, "bold"), background="#b4c7af")

--- a/JsonViewerTab.py
+++ b/JsonViewerTab.py
@@ -15,6 +15,7 @@ from ttkbootstrap.constants import *
 
 # JSONs (per-day and combined) live in the internal backend
 from AppConfig import get_backend_dir
+from ui_scale import scale
 
 
 class JsonViewerTab:
@@ -106,7 +107,9 @@ class JsonViewerTab:
                    "cash", "sur_paye", "frais_admin",
                    "A", "B", "D", "E", "F",
                    "section")
-        self.tree = ttk.Treeview(emp_frame, columns=columns, show="headings")
+        style = ttk.Style()
+        style.configure("Scaled.Treeview", rowheight=scale(25))
+        self.tree = ttk.Treeview(emp_frame, columns=columns, show="headings", style="Scaled.Treeview")
         headings = {
             "id": "#",
             "name": "Nom",
@@ -125,7 +128,7 @@ class JsonViewerTab:
             self.tree.heading(col, text=headings[col])
             anchor = "w" if col in ("name", "section") else "center"
             width = 180 if col == "name" else (90 if col not in ("section",) else 110)
-            self.tree.column(col, anchor=anchor, width=width, stretch=True)
+            self.tree.column(col, anchor=anchor, width=scale(width), stretch=True)
 
         self.tree.pack(fill=BOTH, expand=True)
 

--- a/MainApp.py
+++ b/MainApp.py
@@ -14,6 +14,7 @@ from AppConfig import ensure_pdf_dir_selected, ensure_default_employee_files
 from updater import maybe_auto_check
 from version import APP_NAME, APP_VERSION
 from icon_helper import set_app_icon
+from ui_scale import init_scaling
 
 
 # ---------- Resource & Icon helpers (dev + PyInstaller) ----------
@@ -108,6 +109,8 @@ class TipSplitApp:
 
         self.root = root
         self.root.title(f"{APP_NAME} v{APP_VERSION}")
+        # Configure DPI-aware scaling so the UI looks consistent across displays
+        init_scaling(self.root)
 
         # Start with a size relative to the screen and immediately fit to screen
         self.root.update_idletasks()

--- a/Master.py
+++ b/Master.py
@@ -8,6 +8,7 @@ from tkinter import messagebox
 from MenuBar import create_menu_bar
 
 from AppConfig import ensure_employee_data_ready, get_employee_files
+from ui_scale import scale
 
 
 class MasterSheet:
@@ -28,8 +29,8 @@ class MasterSheet:
 
         # ---------- STYLE: Treeview row height ----------
         style = ttk.Style()
-        style.configure("Treeview", rowheight=25)         # base
-        style.configure("primary.Treeview", rowheight=34) # bootstyle="primary"
+        style.configure("Treeview", rowheight=scale(25))         # base
+        style.configure("primary.Treeview", rowheight=scale(34)) # bootstyle="primary"
 
         # Header Frame
         header_frame = ttk.Frame(self.root)
@@ -108,9 +109,9 @@ class MasterSheet:
         return tree
 
     def _configure_columns(self, tree):
-        tree.column("number", width=120, anchor=CENTER)
-        tree.column("name", width=260, anchor=W)
-        tree.column("points", width=120, anchor=CENTER)
+        tree.column("number", width=scale(120), anchor=CENTER)
+        tree.column("name", width=scale(260), anchor=W)
+        tree.column("points", width=scale(120), anchor=CENTER)
 
     # ---------------------------
     # Sorting

--- a/Pay.py
+++ b/Pay.py
@@ -26,6 +26,7 @@ from tkinter import StringVar, END, Listbox, Text, messagebox
 from ttkbootstrap.constants import *
 
 from AppConfig import get_backend_dir  # JSON_ROOT
+from ui_scale import scale
 
 class PayTab:
     def __init__(self, master):
@@ -90,7 +91,7 @@ class PayTab:
         paned.pack(fill=BOTH, expand=True, padx=10, pady=(0, 10))
 
         # Left (Employee panel) — wider default width
-        left = ttk.Frame(paned, width=340)
+        left = ttk.Frame(paned, width=scale(340))
         left.pack_propagate(False)
         paned.add(left, weight=1)
 
@@ -150,7 +151,7 @@ class PayTab:
 
         for c in self.all_cols:
             self.shift_tree.heading(c, text=base_headings[c])
-            self.shift_tree.column(c, width=widths[c], anchor=anchors[c], stretch=True)
+            self.shift_tree.column(c, width=scale(widths[c]), anchor=anchors[c], stretch=True)
 
         # Zebra striping via tags
         self.shift_tree.tag_configure("odd", background="#f7f7fa")

--- a/TimeSheet.py
+++ b/TimeSheet.py
@@ -15,6 +15,7 @@ from debug_log import log_debug
 
 # Use the centralized AppConfig helpers so paths work on all machines
 from AppConfig import ensure_employee_data_ready
+from ui_scale import scale
 
 
 class TimeSheet:
@@ -52,7 +53,7 @@ class TimeSheet:
 
         # --- Taller rows style ---
         style = ttk.Style()
-        style.configure("Custom.Treeview", font=("Helvetica", 14), rowheight=35)
+        style.configure("Custom.Treeview", font=("Helvetica", 14), rowheight=scale(35))
         style.configure("Custom.Treeview.Heading", font=("Helvetica", 14, "bold"))
         # -------------------------
 
@@ -90,13 +91,13 @@ class TimeSheet:
             else:
                 self.tree.heading(col, text=label)
 
-        self.tree.column("number", width=100, anchor=CENTER)
-        self.tree.column("name", width=200, anchor=W)
-        self.tree.column("points", width=100, anchor=CENTER)
-        self.tree.column("punch", width=50, anchor=CENTER)
-        self.tree.column("in", width=80, anchor=CENTER)
-        self.tree.column("out", width=80, anchor=CENTER)
-        self.tree.column("total", width=80, anchor=CENTER)
+        self.tree.column("number", width=scale(100), anchor=CENTER)
+        self.tree.column("name", width=scale(200), anchor=W)
+        self.tree.column("points", width=scale(100), anchor=CENTER)
+        self.tree.column("punch", width=scale(50), anchor=CENTER)
+        self.tree.column("in", width=scale(80), anchor=CENTER)
+        self.tree.column("out", width=scale(80), anchor=CENTER)
+        self.tree.column("total", width=scale(80), anchor=CENTER)
 
         self.tree.tag_configure("section", font=("Helvetica", 16, "bold"), background="#b4c7af")
         self.tree.tag_configure("hover", background="#e0f7fa")

--- a/ui_scale.py
+++ b/ui_scale.py
@@ -1,0 +1,31 @@
+"""Utility functions for DPI-aware UI scaling.
+
+Call init_scaling(root) once after creating the Tk root to configure
+Tk's internal scaling based on the system's DPI.  Afterwards, use
+scale(value) to multiply pixel values so that widgets have a consistent
+physical size across displays.
+"""
+
+_ui_scale = 1.0
+
+
+def init_scaling(root):
+    """Initialize global scaling based on the display's DPI."""
+    global _ui_scale
+    try:
+        # Tk uses pixels per point (1/72 inch) for its internal scaling.
+        # Query the number of pixels per inch and derive a scale factor.
+        dpi = root.winfo_fpixels("1i")
+        _ui_scale = dpi / 72.0 if dpi > 0 else 1.0
+        root.tk.call("tk", "scaling", _ui_scale)
+    except Exception:
+        _ui_scale = 1.0
+    return _ui_scale
+
+
+def scale(value):
+    """Scale the given pixel value using the configured DPI factor."""
+    try:
+        return int(value * _ui_scale)
+    except Exception:
+        return int(value)


### PR DESCRIPTION
## Summary
- Add `ui_scale` helper to compute and apply DPI-based scaling
- Initialize scaling in `MainApp` and scale pixel-based widget sizes across tabs
- Update various Treeview row heights and column widths to scale with display DPI

## Testing
- `python -m py_compile Distribution.py JsonViewerTab.py MainApp.py Master.py Pay.py TimeSheet.py ui_scale.py`

------
https://chatgpt.com/codex/tasks/task_e_68b5be56af9c8326be33d9e92da9ade7